### PR TITLE
feat: scaffold CGEvent tap and buffering

### DIFF
--- a/app/Core/InputTap.swift
+++ b/app/Core/InputTap.swift
@@ -1,13 +1,92 @@
 import Foundation
+import ApplicationServices
 
+/// Captures global key events using a CGEventTap and forwards
+/// characters into a simple word buffer.
 final class InputTap {
+    private var eventTap: CFMachPort?
+    private var runLoopSource: CFRunLoopSource?
+    private let wordBuffer = WordBuffer()
+
+    /// Prepare the event tap and run loop source.
     func setup() {
-        // TODO: configure CGEventTap
+        guard eventTap == nil else { return }
+
+        let mask = (1 << CGEventType.keyDown.rawValue) |
+                   (1 << CGEventType.keyUp.rawValue)
+
+        eventTap = CGEvent.tapCreate(
+            tap: .cgSessionEventTap,
+            place: .headInsertEventTap,
+            options: .defaultTap,
+            eventsOfInterest: CGEventMask(mask),
+            callback: InputTap.eventCallback,
+            userInfo: UnsafeMutableRawPointer(Unmanaged.passUnretained(self).toOpaque())
+        )
+
+        if let tap = eventTap {
+            runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0)
+        } else {
+            Logger.log("Failed to create event tap")
+        }
     }
+
+    /// Start listening to keyboard events.
     func start() {
-        // TODO: start run loop source
+        guard let tap = eventTap, let src = runLoopSource else { return }
+        CGEvent.tapEnable(tap: tap, enable: true)
+        CFRunLoopAddSource(CFRunLoopGetCurrent(), src, .commonModes)
     }
+
+    /// Stop listening and remove run loop source.
     func stop() {
-        // TODO: stop tap
+        if let tap = eventTap { CGEvent.tapEnable(tap: tap, enable: false) }
+        if let src = runLoopSource {
+            CFRunLoopRemoveSource(CFRunLoopGetCurrent(), src, .commonModes)
+        }
+    }
+
+    private func handleEvent(_ event: CGEvent, type: CGEventType) -> Unmanaged<CGEvent>? {
+        switch type {
+        case .tapDisabledByTimeout:
+            if let tap = eventTap {
+                Logger.log("Event tap disabled by timeout; re-enabling", verbose: true)
+                CGEvent.tapEnable(tap: tap, enable: true)
+            }
+            return nil
+        case .keyDown:
+            let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+            let flags = event.flags.rawValue
+            Logger.log("keyDown code=\(keyCode) flags=\(flags)", verbose: true)
+
+            if wordBuffer.isBoundary(event: event) {
+                wordBuffer.flush()
+            } else {
+                var chars = [UniChar](repeating: 0, count: 4)
+                var length = 0
+                event.keyboardGetUnicodeString(
+                    maxStringLength: 4,
+                    actualStringLength: &length,
+                    unicodeString: &chars
+                )
+                for i in 0..<length {
+                    if let scalar = UnicodeScalar(chars[i]) {
+                        wordBuffer.append(Character(scalar))
+                    }
+                }
+            }
+        case .keyUp:
+            Logger.log("keyUp", verbose: true)
+        default:
+            break
+        }
+
+        return Unmanaged.passUnretained(event)
+    }
+
+    private static let eventCallback: CGEventTapCallBack = { _, type, event, refcon in
+        guard let refcon = refcon, let event = event else { return nil }
+        let tap = Unmanaged<InputTap>.fromOpaque(refcon).takeUnretainedValue()
+        return tap.handleEvent(event, type: type)
     }
 }

--- a/app/Core/Logger.swift
+++ b/app/Core/Logger.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Simple logger with optional verbose output.
+enum Logger {
+    static var isVerbose = false
+
+    static func log(_ msg: String, verbose: Bool = false) {
+        if verbose && !isVerbose { return }
+        NSLog("[Languiny] %@", msg)
+    }
+}

--- a/app/Core/WordBuffer.swift
+++ b/app/Core/WordBuffer.swift
@@ -1,0 +1,28 @@
+import Foundation
+import ApplicationServices
+
+/// Collects characters into a word and flushes on boundary events.
+final class WordBuffer {
+    private var buffer: [Character] = []
+
+    func append(_ char: Character) {
+        buffer.append(char)
+        Logger.log("buffer: \(String(buffer))", verbose: true)
+    }
+
+    /// Detect separators such as space or newline.
+    func isBoundary(event: CGEvent) -> Bool {
+        var chars = [UniChar](repeating: 0, count: 1)
+        var length = 0
+        event.keyboardGetUnicodeString(maxStringLength: 1, actualStringLength: &length, unicodeString: &chars)
+        guard length == 1, let scalar = UnicodeScalar(chars[0]) else { return false }
+        return CharacterSet.whitespacesAndNewlines.contains(scalar)
+    }
+
+    func flush() {
+        if !buffer.isEmpty {
+            Logger.log("flush: \(String(buffer))", verbose: true)
+            buffer.removeAll()
+        }
+    }
+}

--- a/app/UI/MenuBar.swift
+++ b/app/UI/MenuBar.swift
@@ -25,9 +25,3 @@ final class MenuBar {
     @objc private func openPrefs() { Logger.log("Open prefs") }
     @objc private func quit() { NSApp.terminate(nil) }
 }
-
-enum Logger {
-    static func log(_ msg: String) {
-        NSLog("[Languiny] %@", msg)
-    }
-}


### PR DESCRIPTION
## Summary
- implement InputTap with CGEvent tap handling key events and re-enable on timeout
- add WordBuffer stub to accumulate characters and flush on boundaries
- introduce shared Logger with optional verbose logging
- clean up MenuBar to use shared logger

## Testing
- `bash scripts/build_engine.sh`
- `bash scripts/build_app.sh` *(fails: sed: can't read ...)*
- `swiftc -typecheck app/Core/InputTap.swift app/Core/WordBuffer.swift app/Core/Logger.swift app/UI/MenuBar.swift` *(fails: no such module 'ApplicationServices')*

------
https://chatgpt.com/codex/tasks/task_e_6895b0f8a12c832bb2f479079f87f871