### PR TITLE
feat: add accessibility permission prompt

### DIFF
--- a/app/App/KeyboardSwitcherApp.swift
+++ b/app/App/KeyboardSwitcherApp.swift
@@ -11,12 +11,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var menuBar: MenuBar!
     private var axTimer: Timer?
 
+    func applicationWillTerminate(_ notification: Notification) {
+        axTimer?.invalidate()
+        axTimer = nil
+    }
+
     func applicationDidFinishLaunching(_ notification: Notification) {
         Logger.log("Languiny starting…")
         menuBar = MenuBar()
-        menuBar.updateAccessibilityStatus(isTrustedForAccessibility())
+        let trusted = isTrustedForAccessibility()
+        menuBar.updateAccessibilityStatus(trusted)
         startAXStatusTimer()
-        if !isTrustedForAccessibility() {
+        if !trusted {
             promptForAccessibility()
         }
         // Test engine calls
@@ -32,11 +38,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             let trusted = isTrustedForAccessibility()
             self.menuBar.updateAccessibilityStatus(trusted)
         }
+        axTimer?.tolerance = 0.5
     }
 
     private func promptForAccessibility() {
         while !isTrustedForAccessibility() {
+            NSApp.activate(ignoringOtherApps: true)
             let alert = NSAlert()
+            alert.alertStyle = .warning
             alert.messageText = "Accessibility Permission Required"
             alert.informativeText =
                 "Please enable Accessibility for Languiny in System Settings → Privacy & Security → Accessibility."

--- a/app/Core/Accessibility.swift
+++ b/app/Core/Accessibility.swift
@@ -13,5 +13,11 @@ func openAccessibilitySettings() {
     guard let url = URL(
         string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
     ) else { return }
-    NSWorkspace.shared.open(url)
+    
+    if !NSWorkspace.shared.open(url) {
+        // Fallback to the Security & Privacy pane if deep link fails
+        if let fallback = URL(string: "x-apple.systempreferences:com.apple.preference.security") {
+           _ = NSWorkspace.shared.open(fallback)
+       }
+    }
 }

--- a/app/UI/MenuBar.swift
+++ b/app/UI/MenuBar.swift
@@ -23,9 +23,11 @@ final class MenuBar {
     }
 
     func updateAccessibilityStatus(_ trusted: Bool) {
-        statusItem.button?.contentTintColor = trusted ? .systemGreen : .systemRed
+        DispatchQueue.main.async {
+            self.statusItem.button?.contentTintColor = trusted ? .systemGreen : .systemRed
+            self.statusItem.button?.toolTip = trusted ? "Accessibility: Enabled" : "Accessibility: Missing"
+        }
     }
-
     @objc private func toggleEnable() { Logger.log("Toggle enable") }
     @objc private func openPrefs() { Logger.log("Open prefs") }
     @objc private func quit() { NSApp.terminate(nil) }


### PR DESCRIPTION
## Summary
- detect Accessibility permissions and open System Settings if missing
- show blocking prompt and menu icon color for permission status

## Testing
- `make build` *(fails: /bin/zsh not found)*
- `bash scripts/build_engine.sh`
- `bash scripts/build_app.sh` *(fails: sed can't read)*
- `bash -c 'cd engine && go test ./...'`


------
https://chatgpt.com/codex/tasks/task_e_6895b4d3c48c832b811b0cff57828bd9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The app now continuously monitors accessibility permission status and prompts users to grant access if needed, offering options to open system settings, retry, or quit.
  * The menu bar icon now visually indicates accessibility permission status with green or red tint.

* **Enhancements**
  * Improved reliability in detecting accessibility permissions.
  * Added direct link to open macOS Accessibility settings from within the app.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->