### PR TITLE
Core: enumerate and toggle input sources

### DIFF
--- a/app/App/KeyboardSwitcherApp.swift
+++ b/app/App/KeyboardSwitcherApp.swift
@@ -19,6 +19,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     func applicationDidFinishLaunching(_ notification: Notification) {
         Logger.log("Languiny starting…")
         menuBar = MenuBar()
+        ensureDefaultLayoutPair()
+        menuBar.updateToggleTitle()
         let trusted = isTrustedForAccessibility()
         menuBar.updateAccessibilityStatus(trusted)
         startAXStatusTimer()

--- a/app/Core/InputSource.swift
+++ b/app/Core/InputSource.swift
@@ -1,12 +1,53 @@
 import Foundation
+import Carbon
 
-func getCurrentLayoutID() -> String? {
-    // TODO: Use TISCopyCurrentKeyboardInputSource and kTISPropertyInputSourceID
-    return nil
+struct InputSourceInfo: Identifiable {
+    let id: String
+    let name: String
+    let languages: [String]
 }
 
+/// Returns enabled keyboard input sources with their identifiers, localized
+/// names and language tags. Only keyboard layouts are included.
+func listInputSources() -> [InputSourceInfo] {
+    let filter: [CFString: Any] = [
+        kTISPropertyInputSourceCategory: kTISCategoryKeyboardInputSource,
+        kTISPropertyInputSourceType: kTISTypeKeyboardLayout,
+        kTISPropertyInputSourceIsEnabled: true
+    ]
+    guard let cfList = TISCreateInputSourceList(filter as CFDictionary, false)
+        .takeRetainedValue() as? [TISInputSource] else {
+        return []
+    }
+    return cfList.compactMap { src in
+        guard
+            let id = TISGetInputSourceProperty(src, kTISPropertyInputSourceID)?
+                .takeUnretainedValue() as? String,
+            let name = TISGetInputSourceProperty(src, kTISPropertyLocalizedName)?
+                .takeUnretainedValue() as? String
+        else { return nil }
+        let langs = (TISGetInputSourceProperty(src, kTISPropertyInputSourceLanguages)?
+            .takeUnretainedValue() as? [String]) ?? []
+        return InputSourceInfo(id: id, name: name, languages: langs)
+    }
+}
+
+/// Returns the identifier of the current keyboard layout.
+func getCurrentLayoutID() -> String? {
+    guard let src = TISCopyCurrentKeyboardInputSource()?.takeRetainedValue() else {
+        return nil
+    }
+    return TISGetInputSourceProperty(src, kTISPropertyInputSourceID)?
+        .takeUnretainedValue() as? String
+}
+
+/// Activates the input source matching the provided identifier.
 @discardableResult
 func setLayout(by id: String) -> Bool {
-    // TODO: Use TIS APIs to select input source by ID
-    return false
+    let filter: [CFString: Any] = [kTISPropertyInputSourceID: id]
+    guard let list = TISCreateInputSourceList(filter as CFDictionary, false)
+        .takeRetainedValue() as? [TISInputSource], let src = list.first else {
+        return false
+    }
+    return TISSelectInputSource(src) == noErr
 }

--- a/app/Core/Preferences.swift
+++ b/app/Core/Preferences.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+struct LayoutPair: Codable {
+    let fromID: String
+    let toID: String
+}
+
+private let layoutPairKey = "layoutPair"
+
+func loadLayoutPair() -> LayoutPair? {
+    guard let data = UserDefaults.standard.data(forKey: layoutPairKey) else {
+        return nil
+    }
+    return try? JSONDecoder().decode(LayoutPair.self, from: data)
+}
+
+func saveLayoutPair(_ pair: LayoutPair) {
+    if let data = try? JSONEncoder().encode(pair) {
+        UserDefaults.standard.set(data, forKey: layoutPairKey)
+    }
+}
+
+func ensureDefaultLayoutPair() {
+    if loadLayoutPair() == nil {
+        let defaultPair = LayoutPair(fromID: "com.apple.keylayout.US",
+                                     toID: "com.apple.keylayout.Russian")
+        saveLayoutPair(defaultPair)
+    }
+}
+
+@discardableResult
+func toggleLayoutPair() -> Bool {
+    guard let pair = loadLayoutPair(), let current = getCurrentLayoutID() else {
+        return false
+    }
+    let next = current == pair.fromID ? pair.toID : pair.fromID
+    return setLayout(by: next)
+}

--- a/app/UI/MenuBar.swift
+++ b/app/UI/MenuBar.swift
@@ -4,6 +4,7 @@ import SwiftUI
 final class MenuBar {
     private let statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
     private var menu: NSMenu!
+    private var toggleItem: NSMenuItem!
 
     init() {
         setup()
@@ -15,11 +16,14 @@ final class MenuBar {
             button.image?.isTemplate = true
         }
         menu = NSMenu()
+        toggleItem = NSMenuItem(title: "Toggle Layout", action: #selector(toggleLayout), keyEquivalent: "")
+        menu.addItem(toggleItem)
         menu.addItem(NSMenuItem(title: "Enable", action: #selector(toggleEnable), keyEquivalent: ""))
         menu.addItem(NSMenuItem(title: "Preferences…", action: #selector(openPrefs), keyEquivalent: ","))
         menu.addItem(.separator())
         menu.addItem(NSMenuItem(title: "Quit", action: #selector(quit), keyEquivalent: "q"))
         statusItem.menu = menu
+        updateToggleTitle()
     }
 
     func updateAccessibilityStatus(_ trusted: Bool) {
@@ -27,6 +31,21 @@ final class MenuBar {
             self.statusItem.button?.contentTintColor = trusted ? .systemGreen : .systemRed
             self.statusItem.button?.toolTip = trusted ? "Accessibility: Enabled" : "Accessibility: Missing"
         }
+    }
+    func updateToggleTitle() {
+        DispatchQueue.main.async {
+            if let pair = loadLayoutPair(), let currentID = getCurrentLayoutID() {
+                let otherID = currentID == pair.fromID ? pair.toID : pair.fromID
+                let name = listInputSources().first { $0.id == otherID }?.name ?? "Toggle Layout"
+                self.toggleItem.title = "Switch to \(name)"
+            } else {
+                self.toggleItem.title = "Toggle Layout"
+            }
+        }
+    }
+
+    @objc private func toggleLayout() {
+        if toggleLayoutPair() { updateToggleTitle() }
     }
     @objc private func toggleEnable() { Logger.log("Toggle enable") }
     @objc private func openPrefs() { Logger.log("Open prefs") }


### PR DESCRIPTION
## Summary
- Add Carbon TIS wrappers to list, query and change keyboard layouts
- Persist preferred layout pair in UserDefaults and provide toggle utility
- Expose menu bar shortcut to flip between configured layouts

## Testing
- `cd engine && go test ./...`
- `cd app && swift build` *(fails: no such module 'SwiftUI')*


------
https://chatgpt.com/codex/tasks/task_e_6895d831bd68832b8472b818c66d48ae