### PR TITLE
Core: add en_US ↔ ru_RU layout mapping tables

### DIFF
--- a/app/Core/LayoutMapper.swift
+++ b/app/Core/LayoutMapper.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+let enToRu: [Character: Character] = [
+    "`": "ё",
+    "q": "й",
+    "w": "ц",
+    "e": "у",
+    "r": "к",
+    "t": "е",
+    "y": "н",
+    "u": "г",
+    "i": "ш",
+    "o": "щ",
+    "p": "з",
+    "[": "х",
+    "]": "ъ",
+    "a": "ф",
+    "s": "ы",
+    "d": "в",
+    "f": "а",
+    "g": "п",
+    "h": "р",
+    "j": "о",
+    "k": "л",
+    "l": "д",
+    ";": "ж",
+    "'": "э",
+    "z": "я",
+    "x": "ч",
+    "c": "с",
+    "v": "м",
+    "b": "и",
+    "n": "т",
+    "m": "ь",
+    ",": "б",
+    ".": "ю",
+    "/": ".",
+]
+
+var ruToEn: [Character: Character] = {
+    var dict: [Character: Character] = [:]
+    for (k, v) in enToRu {
+        dict[v] = k
+    }
+    return dict
+}()
+
+func preserveCase(_ original: Character, mapped: Character) -> Character {
+    let s = String(original)
+    if s == s.uppercased() && s != s.lowercased() {
+        return Character(String(mapped).uppercased())
+    }
+    return mapped
+}
+
+func mapChar(_ c: Character, using table: [Character: Character]) -> Character {
+    let lower = Character(String(c).lowercased())
+    if let mapped = table[lower] {
+        return preserveCase(c, mapped: mapped)
+    }
+    return c
+}
+
+func mapString(_ s: String, using table: [Character: Character]) -> String {
+    return String(s.map { mapChar($0, using: table) })
+}
+

--- a/docs/layouts.md
+++ b/docs/layouts.md
@@ -7,3 +7,10 @@ Approach:
 - Use key-to-char tables for both directions
 - Word boundary: whitespace, punctuation, Enter
 - Early rules: min word length = 3, ignore URLs/emails patterns
+
+## Mapping rules
+
+- Tables include letters plus punctuation keys that produce letters on the opposite layout.
+- Digits and punctuation that coincide in both layouts stay unchanged.
+- Transformations preserve the case of each character.
+- Characters not present in the table are returned as-is.

--- a/engine/internal/remap/remap.go
+++ b/engine/internal/remap/remap.go
@@ -1,7 +1,15 @@
 package remap
 
 // RemapWord returns a remapped string from layout `from` to `to`.
-// Placeholder: returns input unchanged.
 func RemapWord(s string, from, to int) (string, error) {
-	return s, nil
+	var table map[rune]rune
+	switch {
+	case from == LayoutEnUS && to == LayoutRuRU:
+		table = enToRu
+	case from == LayoutRuRU && to == LayoutEnUS:
+		table = ruToEn
+	default:
+		return s, nil
+	}
+	return mapString(s, table), nil
 }

--- a/engine/internal/remap/remap_test.go
+++ b/engine/internal/remap/remap_test.go
@@ -1,0 +1,39 @@
+package remap
+
+import "testing"
+
+func TestMapStringExamples(t *testing.T) {
+	if got := mapString("ghbdtn", enToRu); got != "привет" {
+		t.Fatalf("ghbdtn -> %q", got)
+	}
+	if got := mapString("привет", ruToEn); got != "ghbdtn" {
+		t.Fatalf("reverse failed: %q", got)
+	}
+}
+
+func TestCasePreservation(t *testing.T) {
+	if got := mapString("Ghbdtn", enToRu); got != "Привет" {
+		t.Fatalf("Ghbdtn -> %q", got)
+	}
+	if got := mapString("GHBDTN", enToRu); got != "ПРИВЕТ" {
+		t.Fatalf("GHBDTN -> %q", got)
+	}
+}
+
+func TestRoundTripLetters(t *testing.T) {
+	en := "`qwertyuiop[]asdfghjkl;'zxcvbnm,./"
+	ru := "ёйцукенгшщзхъфывапролджэячсмитьбю."
+	if back := mapString(mapString(en, enToRu), ruToEn); back != en {
+		t.Fatalf("round trip en->ru->en = %q", back)
+	}
+	if back := mapString(mapString(ru, ruToEn), enToRu); back != ru {
+		t.Fatalf("round trip ru->en->ru = %q", back)
+	}
+}
+
+func TestPunctuationUnaffected(t *testing.T) {
+	input := "12345!@#$% "
+	if got := mapString(input, enToRu); got != input {
+		t.Fatalf("punctuation changed: %q", got)
+	}
+}

--- a/engine/internal/remap/tables.go
+++ b/engine/internal/remap/tables.go
@@ -1,0 +1,78 @@
+package remap
+
+import "unicode"
+
+const (
+	LayoutEnUS = iota
+	LayoutRuRU
+)
+
+var enToRu = map[rune]rune{
+	'`':  'ё',
+	'q':  'й',
+	'w':  'ц',
+	'e':  'у',
+	'r':  'к',
+	't':  'е',
+	'y':  'н',
+	'u':  'г',
+	'i':  'ш',
+	'o':  'щ',
+	'p':  'з',
+	'[':  'х',
+	']':  'ъ',
+	'a':  'ф',
+	's':  'ы',
+	'd':  'в',
+	'f':  'а',
+	'g':  'п',
+	'h':  'р',
+	'j':  'о',
+	'k':  'л',
+	'l':  'д',
+	';':  'ж',
+	'\'': 'э',
+	'z':  'я',
+	'x':  'ч',
+	'c':  'с',
+	'v':  'м',
+	'b':  'и',
+	'n':  'т',
+	'm':  'ь',
+	',':  'б',
+	'.':  'ю',
+	'/':  '.',
+}
+
+var ruToEn map[rune]rune
+
+func init() {
+	ruToEn = make(map[rune]rune, len(enToRu))
+	for k, v := range enToRu {
+		ruToEn[v] = k
+	}
+}
+
+func mapChar(r rune, table map[rune]rune) rune {
+	lower := unicode.ToLower(r)
+	mapped, ok := table[lower]
+	if !ok {
+		return r
+	}
+	return preserveCase(r, mapped)
+}
+
+func mapString(s string, table map[rune]rune) string {
+	out := make([]rune, 0, len(s))
+	for _, r := range s {
+		out = append(out, mapChar(r, table))
+	}
+	return string(out)
+}
+
+func preserveCase(src, dst rune) rune {
+	if unicode.IsUpper(src) {
+		return unicode.ToUpper(dst)
+	}
+	return dst
+}


### PR DESCRIPTION
## Summary
- add bidirectional en_US and ru_RU mapping tables with case preservation in Go and Swift
- implement mapping helpers and RemapWord with two-way layout selection
- document mapping rules for en_US<->ru_RU layouts

## Testing
- `make fmt`
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_6895f29e4d24832b9a9483c1f017c70e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for converting text between English and Russian keyboard layouts, preserving character case and handling punctuation and digits appropriately.

* **Documentation**
  * Updated documentation to clarify the rules and behavior of keyboard layout mapping, including case preservation and handling of unmapped characters.

* **Tests**
  * Introduced comprehensive tests to verify correct mapping, case preservation, round-trip conversions, and handling of punctuation and numeric characters.

* **Bug Fixes**
  * Improved text remapping functionality to accurately convert strings between English and Russian layouts based on user selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->