### PR TITLE
Core: Word buffering and boundary state machine

### DIFF
--- a/app/Core/WordBuffer.swift
+++ b/app/Core/WordBuffer.swift
@@ -5,24 +5,49 @@ import ApplicationServices
 final class WordBuffer {
     private var buffer: [Character] = []
 
+    /// Callback invoked when a word boundary is detected.
+    var onWordBoundary: ((String, Character?) -> Void)?
+
+    /// Append a character to the buffer.
     func append(_ char: Character) {
         buffer.append(char)
         Logger.log("buffer: \(String(buffer))", verbose: true)
     }
 
-    /// Detect separators such as space or newline.
-    func isBoundary(event: CGEvent) -> Bool {
-        var chars = [UniChar](repeating: 0, count: 1)
-        var length = 0
-        event.keyboardGetUnicodeString(maxStringLength: 1, actualStringLength: &length, unicodeString: &chars)
-        guard length == 1, let scalar = UnicodeScalar(chars[0]) else { return false }
-        return CharacterSet.whitespacesAndNewlines.contains(scalar)
+    /// Remove the last character if available.
+    func backspace() {
+        if !buffer.isEmpty { buffer.removeLast() }
+        Logger.log("buffer: \(String(buffer))", verbose: true)
     }
 
-    func flush() {
-        if !buffer.isEmpty {
-            Logger.log("flush: \(String(buffer))", verbose: true)
-            buffer.removeAll()
+    /// Clear the buffer entirely.
+    func reset() {
+        buffer.removeAll()
+    }
+
+    /// Determine if a key event represents a word boundary and return the separator.
+    func boundary(for event: CGEvent) -> Character? {
+        var chars = [UniChar](repeating: 0, count: 4)
+        var length = 0
+        event.keyboardGetUnicodeString(maxStringLength: 4, actualStringLength: &length, unicodeString: &chars)
+        guard length > 0 else { return nil }
+        for i in 0..<length {
+            guard let scalar = UnicodeScalar(chars[i]) else { continue }
+            if CharacterSet.whitespacesAndNewlines.contains(scalar) ||
+                CharacterSet.punctuationCharacters.contains(scalar) {
+                return Character(scalar)
+            }
+        }
+        return nil
+    }
+
+    /// Flush the current buffer and emit boundary callback.
+    func flush(separator: Character? = nil) {
+        let word = String(buffer)
+        buffer.removeAll()
+        if !word.isEmpty || separator != nil {
+            Logger.log("flush: \(word) sep=\(String(describing: separator))", verbose: true)
+            onWordBoundary?(word, separator)
         }
     }
 }

--- a/app/Tests/CoreTests/WordBufferTests.swift
+++ b/app/Tests/CoreTests/WordBufferTests.swift
@@ -1,0 +1,83 @@
+import XCTest
+@testable import Languiny
+import ApplicationServices
+
+final class WordBufferTests: XCTestCase {
+    private func makeEvent(char: Character, pid: Int32 = 1, keyCode: CGKeyCode = 0) -> CGEvent {
+        let event = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true)!
+        var utf16 = Array(String(char).utf16)
+        event.keyboardSetUnicodeString(stringLength: utf16.count, unicodeString: &utf16)
+        event.setIntegerValueField(.eventSourceUnixProcessID, value: Int64(pid))
+        return event
+    }
+
+    private func makeArrowEvent(pid: Int32 = 1, keyCode: CGKeyCode = 123) -> CGEvent {
+        let event = CGEvent(keyboardEventSource: nil, virtualKey: keyCode, keyDown: true)!
+        event.setIntegerValueField(.eventSourceUnixProcessID, value: Int64(pid))
+        return event
+    }
+
+    private func makeBackspaceEvent(pid: Int32 = 1) -> CGEvent {
+        let event = CGEvent(keyboardEventSource: nil, virtualKey: 51, keyDown: true)!
+        event.setIntegerValueField(.eventSourceUnixProcessID, value: Int64(pid))
+        return event
+    }
+
+    func testWordBoundaries() {
+        let tap = InputTap()
+        var results: [(String, Character?)] = []
+        tap.onWordBoundary = { word, sep in results.append((word, sep)) }
+
+        for c in "test" { _ = tap.handleEvent(makeEvent(char: c), type: .keyDown) }
+        _ = tap.handleEvent(makeEvent(char: " ", keyCode: 49), type: .keyDown)
+        for c in "next" { _ = tap.handleEvent(makeEvent(char: c), type: .keyDown) }
+        _ = tap.handleEvent(makeArrowEvent(), type: .keyDown)
+
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].0, "test")
+        XCTAssertEqual(results[0].1, " ")
+        XCTAssertEqual(results[1].0, "next")
+        XCTAssertNil(results[1].1)
+    }
+
+    func testBackspaceUpdatesBuffer() {
+        let tap = InputTap()
+        var results: [(String, Character?)] = []
+        tap.onWordBoundary = { word, sep in results.append((word, sep)) }
+
+        for c in "ab" { _ = tap.handleEvent(makeEvent(char: c), type: .keyDown) }
+        _ = tap.handleEvent(makeBackspaceEvent(), type: .keyDown)
+        _ = tap.handleEvent(makeBackspaceEvent(), type: .keyDown)
+        _ = tap.handleEvent(makeBackspaceEvent(), type: .keyDown)
+        _ = tap.handleEvent(makeArrowEvent(), type: .keyDown)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].0, "")
+    }
+
+    func testSwitchingAppsFlushes() {
+        let tap = InputTap()
+        var results: [(String, Character?)] = []
+        tap.onWordBoundary = { word, sep in results.append((word, sep)) }
+
+        _ = tap.handleEvent(makeEvent(char: "a", pid: 1), type: .keyDown)
+        _ = tap.handleEvent(makeEvent(char: "b", pid: 2), type: .keyDown)
+        _ = tap.handleEvent(makeArrowEvent(pid: 2), type: .keyDown)
+
+        XCTAssertEqual(results.count, 2)
+        XCTAssertEqual(results[0].0, "a")
+        XCTAssertEqual(results[1].0, "b")
+    }
+
+    func testArrowKeysFlush() {
+        let tap = InputTap()
+        var results: [(String, Character?)] = []
+        tap.onWordBoundary = { word, sep in results.append((word, sep)) }
+
+        for c in "ab" { _ = tap.handleEvent(makeEvent(char: c), type: .keyDown) }
+        _ = tap.handleEvent(makeArrowEvent(), type: .keyDown)
+
+        XCTAssertEqual(results.count, 1)
+        XCTAssertEqual(results[0].0, "ab")
+    }
+}


### PR DESCRIPTION
## Summary
- implement WordBuffer with boundary detection, backspace, reset and flush callbacks
- hook InputTap to flush on app switches, arrow keys and backspace while exposing word boundary events
- add tests covering word boundaries, backspace, app switching and arrow-key flushing

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_689604b99320832ba87aa0129decd941

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved word boundary detection for keyboard input, including support for arrow keys and backspace handling.
  * Added callback functionality to notify when a word boundary is detected, with details about the word and separator.
  * Enhanced buffer management, including new options to backspace and reset the buffer.

* **Bug Fixes**
  * Ensured accurate buffer flushing when switching between applications or using navigation keys.

* **Tests**
  * Introduced comprehensive tests to verify word boundary detection, buffer updates, and application-switching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->