### PR TITLE
Add preferences UI and settings persistence

### DIFF
--- a/app/Core/InputTap.swift
+++ b/app/Core/InputTap.swift
@@ -133,6 +133,12 @@ final class InputTap {
             Logger.log("boundary: missing layout info", verbose: true)
             return
         }
+        guard autoFixEnabled() else { return }
+        if shouldIgnoreUrlsEmails() && looksLikeUrlOrEmail(word) {
+            let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1000
+            Logger.log("ignore: \(word) in \(Int(elapsed))ms", verbose: true)
+            return
+        }
         let currentLayout: Int32
         let targetLayout: Int32
         let targetID: String
@@ -162,6 +168,16 @@ final class InputTap {
             let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1000
             Logger.log("no switch: \(word) in \(Int(elapsed))ms", verbose: true)
         }
+    }
+
+    private func looksLikeUrlOrEmail(_ word: String) -> Bool {
+        if word.range(of: #"^[A-Za-z]+://"#, options: .regularExpression) != nil {
+            return true
+        }
+        if word.range(of: #"^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$"#, options: [.regularExpression, .caseInsensitive]) != nil {
+            return true
+        }
+        return false
     }
 
     func handleEvent(_ event: CGEvent, type: CGEventType) -> Unmanaged<CGEvent>? {

--- a/app/UI/MenuBar.swift
+++ b/app/UI/MenuBar.swift
@@ -6,12 +6,14 @@ final class MenuBar {
     private var menu: NSMenu!
     private var toggleItem: NSMenuItem!
     private var enableItem: NSMenuItem!
+    private var prefsWindow: NSWindow?
 
     private var isEnabled = true
     var onToggleEnable: ((Bool) -> Void)?
 
     init() {
         setup()
+        NotificationCenter.default.addObserver(self, selector: #selector(handleLayoutPairChange), name: layoutPairChangedNotification, object: nil)
     }
 
     private func setup() {
@@ -75,7 +77,16 @@ final class MenuBar {
         onToggleEnable?(isEnabled)
     }
 
-    @objc private func openPrefs() { Logger.log("Open prefs") }
+    @objc private func openPrefs() {
+        if prefsWindow == nil {
+            let controller = NSHostingController(rootView: PreferencesView())
+            let window = NSWindow(contentViewController: controller)
+            window.title = "Preferences"
+            prefsWindow = window
+        }
+        prefsWindow?.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
 
     @objc private func openAbout() {
         let appVersion = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "?"
@@ -88,4 +99,6 @@ final class MenuBar {
     }
 
     @objc private func quit() { NSApp.terminate(nil) }
+
+    @objc private func handleLayoutPairChange() { updateToggleTitle() }
 }

--- a/app/UI/PreferencesView.swift
+++ b/app/UI/PreferencesView.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+import AppKit
+
+final class PreferencesViewModel: ObservableObject {
+    @Published var layouts: [InputSourceInfo] = listInputSources()
+    @Published var fromID: String
+    @Published var toID: String
+    @Published var autoFix: Bool
+    @Published var ignoreURLs: Bool
+    @Published var bypassOption: Bool
+    @Published var appListMode: AppListMode
+    @Published var appListText: String
+
+    init() {
+        let pair = loadLayoutPair()
+        self.fromID = pair?.fromID ?? ""
+        self.toID = pair?.toID ?? ""
+        self.autoFix = autoFixEnabled()
+        self.ignoreURLs = shouldIgnoreUrlsEmails()
+        self.bypassOption = shouldBypassOption()
+        self.appListMode = loadAppListMode()
+        self.appListText = loadAppList().joined(separator: "\n")
+    }
+
+    private func persistLayoutPair() {
+        let pair = LayoutPair(fromID: fromID, toID: toID)
+        saveLayoutPair(pair)
+    }
+
+    private func saveBehavior() {
+        setAutoFixEnabled(autoFix)
+        setIgnoreUrlsEmails(ignoreURLs)
+        setBypassOption(bypassOption)
+    }
+
+    private func saveApps() {
+        saveAppListMode(appListMode)
+        let ids = appListText
+            .split(whereSeparator: { $0.isNewline })
+            .map { String($0).trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        saveAppList(Set(ids))
+    }
+
+    func exportPrefs() {
+        guard let data = exportPreferences() else { return }
+        let panel = NSSavePanel()
+        panel.nameFieldStringValue = "languiny_prefs.json"
+        panel.allowedFileTypes = ["json"]
+        if panel.runModal() == .OK, let url = panel.url {
+            try? data.write(to: url)
+        }
+    }
+
+    func importPrefs() {
+        let panel = NSOpenPanel()
+        panel.allowedFileTypes = ["json"]
+        if panel.runModal() == .OK, let url = panel.url, let data = try? Data(contentsOf: url) {
+            importPreferences(data: data)
+            // Reload from defaults
+            let pair = loadLayoutPair()
+            fromID = pair?.fromID ?? ""
+            toID = pair?.toID ?? ""
+            autoFix = autoFixEnabled()
+            ignoreURLs = shouldIgnoreUrlsEmails()
+            bypassOption = shouldBypassOption()
+            appListMode = loadAppListMode()
+            appListText = loadAppList().joined(separator: "\n")
+        }
+    }
+
+    func onLayoutChange() { persistLayoutPair() }
+    func onBehaviorChange() { saveBehavior() }
+    func onAppsChange() { saveApps() }
+}
+
+struct PreferencesView: View {
+    @StateObject private var model = PreferencesViewModel()
+
+    var body: some View {
+        VStack(alignment: .leading) {
+            Form {
+                Section("Layout Pair") {
+                    Picker("From", selection: $model.fromID) {
+                        ForEach(model.layouts) { layout in
+                            Text(layout.name).tag(layout.id)
+                        }
+                    }
+                    .onChange(of: model.fromID) { _ in model.onLayoutChange() }
+
+                    Picker("To", selection: $model.toID) {
+                        ForEach(model.layouts) { layout in
+                            Text(layout.name).tag(layout.id)
+                        }
+                    }
+                    .onChange(of: model.toID) { _ in model.onLayoutChange() }
+                }
+
+                Section("Behavior") {
+                    Toggle("Auto-fix on word boundary", isOn: $model.autoFix)
+                        .onChange(of: model.autoFix) { _ in model.onBehaviorChange() }
+                    Toggle("Ignore URLs and emails", isOn: $model.ignoreURLs)
+                        .onChange(of: model.ignoreURLs) { _ in model.onBehaviorChange() }
+                    Toggle("Bypass Option key", isOn: $model.bypassOption)
+                        .onChange(of: model.bypassOption) { _ in model.onBehaviorChange() }
+                }
+
+                Section("Apps") {
+                    Picker("Mode", selection: $model.appListMode) {
+                        Text("Whitelist").tag(AppListMode.whitelist)
+                        Text("Blacklist").tag(AppListMode.blacklist)
+                    }
+                    .pickerStyle(SegmentedPickerStyle())
+                    .onChange(of: model.appListMode) { _ in model.onAppsChange() }
+                    TextEditor(text: $model.appListText)
+                        .frame(minHeight: 80)
+                        .onChange(of: model.appListText) { _ in model.onAppsChange() }
+                }
+            }
+            HStack {
+                Button("Import…") { model.importPrefs() }
+                Button("Export…") { model.exportPrefs() }
+                Spacer()
+            }
+        }
+        .padding()
+        .frame(width: 400, height: 400)
+    }
+}
+


### PR DESCRIPTION
## Summary
- add SwiftUI preferences window for configuring layout pairs, behaviors, and app lists
- persist settings via UserDefaults with export/import JSON helpers
- apply settings live; engine tap now checks auto-fix and URL/email ignore toggles
- fix layout pair persistence helper naming to avoid build error

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689610e53a7c832bb6c895ae6d7051f9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new Preferences window with an intuitive interface for managing keyboard layouts, behavior toggles, and app-specific settings.
  * Added options to enable or disable auto-fix on word boundaries and to ignore URLs/emails.
  * Enabled importing and exporting of all user preferences as JSON files.

* **Improvements**
  * Preferences now update in real time when settings are changed, with immediate effect across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->