### PR TITLE
perf: add micro-benchmarks and latency metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ make build-app
 make run
 ```
 
+## Preferences
+
+The app includes a Preferences window (`⌘,`) where you can:
+
+- Select the pair of keyboard layouts to toggle between.
+- Enable or disable behaviors like auto-fix on word boundary, ignoring URLs/emails, and bypassing the Option key.
+- Maintain a whitelist or blacklist of application bundle identifiers (one bundle ID per line).
+
+All changes apply immediately and persist across restarts. Settings are stored using `UserDefaults` and can be exported or imported as JSON for easy backup or sharing.
+
 ## Layout
 
 ```

--- a/app/Core/InputTap.swift
+++ b/app/Core/InputTap.swift
@@ -16,6 +16,7 @@ final class InputTap {
     // Flag to avoid handling events we synthesize ourselves
     private var isInjecting = false
     private var suppressedKeyUp: CGKeyCode?
+    private let boundaryMetrics = RollingMetrics(capacity: 100)
 
     // Debug options
     var injectionEnabled = true
@@ -137,7 +138,8 @@ final class InputTap {
         let candidate = word.trimmingCharacters(in: CharacterSet(charactersIn: ".,!?:;)]}"))
         if shouldIgnoreUrlsEmails() && looksLikeUrlOrEmail(candidate) {
             let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1000
-            Logger.log("ignore: \(word) in \(Int(elapsed))ms", verbose: true)
+            boundaryMetrics.record(elapsed)
+            Logger.log("ignore: \(word) in \(Int(elapsed))ms (avg \(Int(boundaryMetrics.average()))ms)", verbose: true)
             return
         }
         let currentLayout: Int32
@@ -164,10 +166,12 @@ final class InputTap {
             let text = mapped + (separator.map { String($0) } ?? "")
             inject(text: text)
             let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1000
-            Logger.log("switch: \(word) -> \(mapped) in \(Int(elapsed))ms")
+            boundaryMetrics.record(elapsed)
+            Logger.log("switch: \(word) -> \(mapped) in \(Int(elapsed))ms (avg \(Int(boundaryMetrics.average()))ms)")
         } else {
             let elapsed = (CFAbsoluteTimeGetCurrent() - start) * 1000
-            Logger.log("no switch: \(word) in \(Int(elapsed))ms", verbose: true)
+            boundaryMetrics.record(elapsed)
+            Logger.log("no switch: \(word) in \(Int(elapsed))ms (avg \(Int(boundaryMetrics.average()))ms)", verbose: true)
         }
     }
 

--- a/app/Core/Metrics.swift
+++ b/app/Core/Metrics.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Records the last N timing samples and computes averages.
+final class RollingMetrics {
+    private var samples: [Double] = []
+    private let capacity: Int
+    init(capacity: Int) { self.capacity = capacity }
+
+    /// Add a new measurement in milliseconds.
+    func record(_ value: Double) {
+        samples.append(value)
+        if samples.count > capacity { samples.removeFirst(samples.count - capacity) }
+    }
+
+    /// Compute the average of recorded samples.
+    func average() -> Double {
+        guard !samples.isEmpty else { return 0 }
+        return samples.reduce(0, +) / Double(samples.count)
+    }
+}

--- a/app/UI/PreferencesView.swift
+++ b/app/UI/PreferencesView.swift
@@ -125,6 +125,7 @@ struct PreferencesView: View {
                     .pickerStyle(SegmentedPickerStyle())
                     .onChange(of: model.appListMode) { _ in model.onAppsChange() }
                     TextEditor(text: $model.appListText)
+                        .font(.system(.body, design: .monospaced))
                         .frame(minHeight: 80)
                         .onChange(of: model.appListText) { _ in model.onAppsChange() }
                 }

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,51 @@
+# Integration Test Checklist
+
+Manual QA matrix to verify Languiny across common macOS apps.
+
+## Environment
+
+- Apple Silicon Mac
+- macOS 15.5
+
+## Apps
+
+- TextEdit
+- Notes
+- Safari
+- Mail
+- VS Code
+- Xcode
+
+## Scenarios
+
+For each app, verify:
+
+- [ ] Plain typing
+- [ ] Backspace and editing
+- [ ] App switching while typing
+- [ ] Long words (50+ characters)
+- [ ] Punctuation handling
+- [ ] URLs and email addresses
+
+## Matrix
+
+Record pass/fail and notes for each scenario:
+
+| App     | Plain | Edit | Switch | Long | Punct | URL/Email | Notes |
+|---------|-------|------|--------|------|-------|-----------|-------|
+| TextEdit| [ ]   | [ ]  | [ ]    | [ ]  | [ ]   | [ ]       |       |
+| Notes   | [ ]   | [ ]  | [ ]    | [ ]  | [ ]   | [ ]       |       |
+| Safari  | [ ]   | [ ]  | [ ]    | [ ]  | [ ]   | [ ]       |       |
+| Mail    | [ ]   | [ ]  | [ ]    | [ ]  | [ ]   | [ ]       |       |
+| VS Code | [ ]   | [ ]  | [ ]    | [ ]  | [ ]   | [ ]       |       |
+| Xcode   | [ ]   | [ ]  | [ ]    | [ ]  | [ ]   | [ ]       |       |
+
+## Logging and Timing
+
+- Use `log stream --process Languiny` to capture engine decisions.
+- Measure switching latency with `time` around the app build and run cycle.
+
+## Known Exceptions
+
+Document any apps that block synthetic events or require special configuration (e.g., enabling the blacklist in IDEs).
+

--- a/engine/internal/detect/detect_benchmark_test.go
+++ b/engine/internal/detect/detect_benchmark_test.go
@@ -1,0 +1,9 @@
+package detect
+
+import "testing"
+
+func BenchmarkShouldSwitch(b *testing.B) {
+    for i := 0; i < b.N; i++ {
+        ShouldSwitch("abcdefghijkl", 0)
+    }
+}

--- a/engine/internal/remap/remap_test.go
+++ b/engine/internal/remap/remap_test.go
@@ -37,3 +37,9 @@ func TestPunctuationUnaffected(t *testing.T) {
 		t.Fatalf("punctuation changed: %q", got)
 	}
 }
+
+func BenchmarkRemapWord(b *testing.B) {
+    for i := 0; i < b.N; i++ {
+        RemapWord("abcdefghijkl", LayoutEnUS, LayoutRuRU)
+    }
+}


### PR DESCRIPTION
## Summary
- add rolling timing metrics for word boundary decisions and log running averages
- introduce Go benchmarks for remapping and switch detection

## Testing
- `cd app && swift test` *(fails: no such module 'SwiftUI')*
- `cd engine && go test ./...` *(fails: no required module provides package github.com/you/kbd-switch/engine/internal/detect)*

------
https://chatgpt.com/codex/tasks/task_e_68963c58faec832ba7724157fbcd451e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a detailed "Preferences" section to the documentation, explaining configurable options and JSON import/export.
  * Introduced a manual QA checklist for integration testing across common macOS applications.
  * Implemented performance tracking for word boundary handling, with average processing times now reported.
  * Preferences "Apps" list now uses a monospaced font for improved readability.

* **Tests**
  * Added benchmark tests for key functions to measure performance in detection and remapping logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->