### PR TITLE
Add versioned settings model and store

### DIFF
--- a/app/App/KeyboardSwitcherApp.swift
+++ b/app/App/KeyboardSwitcherApp.swift
@@ -12,6 +12,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var axTimer: Timer?
     private let tap = InputTap()
     private var enabled = true
+    private let settingsStore = SettingsStore.shared
 
     func applicationWillTerminate(_ notification: Notification) {
         axTimer?.invalidate()
@@ -20,6 +21,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     }
 
     func applicationDidFinishLaunching(_ notification: Notification) {
+        _ = settingsStore.load()
         Logger.log("Languiny starting…")
         menuBar = MenuBar()
         menuBar.onToggleEnable = { [weak self] newValue in

--- a/app/App/Settings/Defaults.swift
+++ b/app/App/Settings/Defaults.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+enum Defaults {
+    static let settings = Settings(
+        languages: .init(primary: "en_US", secondary: "ru_RU"),
+        detection: .init(autoDetect: true),
+        switching: .init(automatic: true),
+        retro: .init(enabled: true),
+        rules: .init(minWordLength: 3),
+        apps: .init(blacklist: [], whitelist: []),
+        hotkeys: .init(toggle: "cmd+shift+space"),
+        ui: .init(showMenuBarIcon: true),
+        learning: .init(enabled: true),
+        privacy: .init(analytics: false),
+        performance: .init(debounceMS: 50),
+        startup: .init(launchAtLogin: false),
+        version: 1
+    )
+}

--- a/app/App/Settings/Settings.swift
+++ b/app/App/Settings/Settings.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+struct Settings: Codable, Equatable {
+    struct Languages: Codable, Equatable {
+        var primary: String
+        var secondary: String
+    }
+
+    struct Detection: Codable, Equatable {
+        var autoDetect: Bool
+    }
+
+    struct Switching: Codable, Equatable {
+        var automatic: Bool
+    }
+
+    struct Retro: Codable, Equatable {
+        var enabled: Bool
+    }
+
+    struct Rules: Codable, Equatable {
+        var minWordLength: Int
+    }
+
+    struct Apps: Codable, Equatable {
+        var blacklist: [String]
+        var whitelist: [String]
+    }
+
+    struct Hotkeys: Codable, Equatable {
+        var toggle: String
+    }
+
+    struct UI: Codable, Equatable {
+        var showMenuBarIcon: Bool
+    }
+
+    struct Learning: Codable, Equatable {
+        var enabled: Bool
+    }
+
+    struct Privacy: Codable, Equatable {
+        var analytics: Bool
+    }
+
+    struct Performance: Codable, Equatable {
+        var debounceMS: Int
+    }
+
+    struct Startup: Codable, Equatable {
+        var launchAtLogin: Bool
+    }
+
+    var languages: Languages
+    var detection: Detection
+    var switching: Switching
+    var retro: Retro
+    var rules: Rules
+    var apps: Apps
+    var hotkeys: Hotkeys
+    var ui: UI
+    var learning: Learning
+    var privacy: Privacy
+    var performance: Performance
+    var startup: Startup
+    var version: Int
+}

--- a/app/App/Settings/SettingsMigration.swift
+++ b/app/App/Settings/SettingsMigration.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+enum SettingsMigration {
+    /// Placeholder for future migrations. Returns the input data unchanged for v1.
+    static func migrateIfNeeded(_ data: Data) throws -> Data {
+        // In the future, inspect JSON and migrate older versions here.
+        return data
+    }
+}

--- a/app/App/Settings/SettingsStore.swift
+++ b/app/App/Settings/SettingsStore.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+extension Notification.Name {
+    static let settingsDidChange = Notification.Name("settingsDidChange")
+}
+
+final class SettingsStore {
+    static let shared = SettingsStore()
+
+    private let url: URL
+    private let encoder = JSONEncoder()
+    private let decoder = JSONDecoder()
+    private(set) var settings: Settings
+
+    init(directory: URL? = nil) {
+        let baseDir: URL
+        if let directory = directory {
+            baseDir = directory
+        } else {
+            let fm = FileManager.default
+            baseDir = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+                .appendingPathComponent("Languiny", isDirectory: true)
+        }
+        url = baseDir.appendingPathComponent("settings.json")
+        try? FileManager.default.createDirectory(at: baseDir, withIntermediateDirectories: true)
+        settings = Defaults.settings
+        _ = load()
+    }
+
+    @discardableResult
+    func load() -> Settings {
+        if let data = try? Data(contentsOf: url),
+           let migrated = try? SettingsMigration.migrateIfNeeded(data),
+           let decoded = try? decoder.decode(Settings.self, from: migrated) {
+            settings = decoded
+        } else {
+            settings = Defaults.settings
+            save()
+        }
+        return settings
+    }
+
+    func update(_ block: (inout Settings) -> Void) {
+        block(&settings)
+        save()
+        NotificationCenter.default.post(name: .settingsDidChange, object: settings)
+    }
+
+    private func save() {
+        if let data = try? encoder.encode(settings) {
+            try? data.write(to: url, options: [.atomic])
+        }
+    }
+}

--- a/app/Tests/SettingsTests/SettingsStoreTests.swift
+++ b/app/Tests/SettingsTests/SettingsStoreTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import Languiny
+
+final class SettingsStoreTests: XCTestCase {
+    func testRoundTripCodable() throws {
+        let original = Defaults.settings
+        let data = try JSONEncoder().encode(original)
+        let decoded = try JSONDecoder().decode(Settings.self, from: data)
+        XCTAssertEqual(original, decoded)
+    }
+
+    func testDefaultProvisioning() throws {
+        let tmp = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        let store = SettingsStore(directory: tmp)
+        let settings = store.load()
+        XCTAssertEqual(settings, Defaults.settings)
+    }
+}


### PR DESCRIPTION
## Summary
- add Codable v1 Settings model with nested categories
- persist settings via JSON-based SettingsStore with change notifications and migration stub
- load settings on startup and cover encoding/decoding with tests

## Testing
- `swift test` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6896fca4e574832bbb73540bc306e629

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a structured settings system with customizable options for language, detection, switching, UI, privacy, and more.
  * Settings are now persistently stored and automatically loaded at app launch.
  * Default settings are provided for a streamlined initial setup.

* **Improvements**
  * Added support for future settings migration to ensure compatibility across app updates.

* **Bug Fixes**
  * Ensured settings are reliably loaded and reset to defaults if corrupted.

* **Tests**
  * Added tests to verify correct settings encoding/decoding and default provisioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->