### PR TITLE
Add tabbed preferences and input source mapping

### DIFF
--- a/app/App/Preferences/PreferencesWindowController.swift
+++ b/app/App/Preferences/PreferencesWindowController.swift
@@ -1,0 +1,23 @@
+import AppKit
+
+final class PreferencesWindowController: NSWindowController {
+    private let tabController = NSTabViewController()
+
+    init() {
+        super.init(window: nil)
+        let window = NSWindow(contentViewController: tabController)
+        window.title = "Preferences"
+        window.styleMask = [.titled, .closable, .miniaturizable]
+        window.setContentSize(NSSize(width: 500, height: 400))
+        self.window = window
+
+        let general = GeneralTabViewController()
+        general.title = "General"
+        tabController.addChild(general)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/app/App/Preferences/Tabs/GeneralTabViewController.swift
+++ b/app/App/Preferences/Tabs/GeneralTabViewController.swift
@@ -1,0 +1,156 @@
+import AppKit
+
+final class GeneralTabViewController: NSViewController, NSTableViewDataSource, NSTableViewDelegate {
+    private struct Mapping {
+        var language: String
+        var layoutID: String
+    }
+
+    private let settingsStore = SettingsStore.shared
+    private var sources: [KeyboardInputSource] = []
+    private var activeLayouts: Set<String> = []
+    private var mappings: [Mapping] = []
+
+    private let layoutsStack = NSStackView()
+    private let mappingTable = NSTableView()
+
+    override func loadView() {
+        view = NSView()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        sources = InputSourcesService.shared.list()
+        activeLayouts = Set(settingsStore.settings.layouts.active)
+        mappings = settingsStore.settings.layouts.languageMap.map { Mapping(language: $0.key, layoutID: $0.value) }
+        setupUI()
+    }
+
+    private func setupUI() {
+        layoutsStack.orientation = .vertical
+        layoutsStack.alignment = .leading
+        layoutsStack.spacing = 4
+        for src in sources {
+            let btn = NSButton(checkboxWithTitle: src.name, target: self, action: #selector(layoutToggled(_:)))
+            btn.identifier = NSUserInterfaceItemIdentifier(src.id)
+            btn.state = activeLayouts.contains(src.id) ? .on : .off
+            layoutsStack.addArrangedSubview(btn)
+        }
+        let layoutsScroll = NSScrollView()
+        layoutsScroll.documentView = layoutsStack
+        layoutsScroll.hasVerticalScroller = true
+        layoutsScroll.translatesAutoresizingMaskIntoConstraints = false
+
+        // Mapping table
+        let langColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("language"))
+        langColumn.title = "Language"
+        let layoutColumn = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("layout"))
+        layoutColumn.title = "Layout"
+        mappingTable.addTableColumn(langColumn)
+        mappingTable.addTableColumn(layoutColumn)
+        mappingTable.delegate = self
+        mappingTable.dataSource = self
+        let mappingScroll = NSScrollView()
+        mappingScroll.documentView = mappingTable
+        mappingScroll.hasVerticalScroller = true
+        mappingScroll.translatesAutoresizingMaskIntoConstraints = false
+
+        let addButton = NSButton(title: "+", target: self, action: #selector(addMapping))
+        let removeButton = NSButton(title: "-", target: self, action: #selector(removeMapping))
+        let buttonsStack = NSStackView(views: [addButton, removeButton])
+        buttonsStack.orientation = .horizontal
+        buttonsStack.spacing = 4
+        buttonsStack.translatesAutoresizingMaskIntoConstraints = false
+
+        let mainStack = NSStackView()
+        mainStack.orientation = .vertical
+        mainStack.spacing = 8
+        mainStack.translatesAutoresizingMaskIntoConstraints = false
+        mainStack.addArrangedSubview(NSTextField(labelWithString: "Active layouts"))
+        mainStack.addArrangedSubview(layoutsScroll)
+        mainStack.addArrangedSubview(NSTextField(labelWithString: "Language → Layout"))
+        mainStack.addArrangedSubview(mappingScroll)
+        mainStack.addArrangedSubview(buttonsStack)
+
+        view.addSubview(mainStack)
+        NSLayoutConstraint.activate([
+            mainStack.topAnchor.constraint(equalTo: view.topAnchor, constant: 20),
+            mainStack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            mainStack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            mainStack.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -20),
+            layoutsScroll.heightAnchor.constraint(equalToConstant: 120),
+            mappingScroll.heightAnchor.constraint(equalToConstant: 150)
+        ])
+    }
+
+    @objc private func layoutToggled(_ sender: NSButton) {
+        guard let id = sender.identifier?.rawValue else { return }
+        if sender.state == .on {
+            activeLayouts.insert(id)
+        } else {
+            activeLayouts.remove(id)
+        }
+        settingsStore.update { $0.layouts.active = Array(activeLayouts) }
+    }
+
+    @objc private func addMapping() {
+        mappings.append(Mapping(language: "", layoutID: sources.first?.id ?? ""))
+        mappingTable.reloadData()
+        saveMappings()
+    }
+
+    @objc private func removeMapping() {
+        let row = mappingTable.selectedRow
+        guard row >= 0 && row < mappings.count else { return }
+        mappings.remove(at: row)
+        mappingTable.reloadData()
+        saveMappings()
+    }
+
+    private func saveMappings() {
+        let dict = Dictionary(uniqueKeysWithValues: mappings.map { ($0.language, $0.layoutID) })
+        settingsStore.update { $0.layouts.languageMap = dict }
+    }
+
+    // MARK: NSTableView
+    func numberOfRows(in tableView: NSTableView) -> Int { mappings.count }
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+        let mapping = mappings[row]
+        if tableColumn?.identifier.rawValue == "language" {
+            let tf = NSTextField(string: mapping.language)
+            tf.isBordered = false
+            tf.backgroundColor = .clear
+            tf.action = #selector(languageChanged(_:))
+            tf.target = self
+            tf.tag = row
+            return tf
+        } else {
+            let popup = NSPopUpButton()
+            popup.addItems(withTitles: sources.map { $0.name })
+            if let idx = sources.firstIndex(where: { $0.id == mapping.layoutID }) {
+                popup.selectItem(at: idx)
+            }
+            popup.tag = row
+            popup.target = self
+            popup.action = #selector(layoutChanged(_:))
+            return popup
+        }
+    }
+
+    @objc private func languageChanged(_ sender: NSTextField) {
+        let row = sender.tag
+        guard row >= 0 && row < mappings.count else { return }
+        mappings[row].language = sender.stringValue
+        saveMappings()
+    }
+
+    @objc private func layoutChanged(_ sender: NSPopUpButton) {
+        let row = sender.tag
+        guard row >= 0 && row < mappings.count else { return }
+        let idx = sender.indexOfSelectedItem
+        guard idx >= 0 && idx < sources.count else { return }
+        mappings[row].layoutID = sources[idx].id
+        saveMappings()
+    }
+}

--- a/app/App/Services/InputSourcesService.swift
+++ b/app/App/Services/InputSourcesService.swift
@@ -1,0 +1,44 @@
+import Carbon
+import Foundation
+
+struct KeyboardInputSource: Identifiable {
+    let id: String
+    let name: String
+    let languages: [String]
+}
+
+final class InputSourcesService {
+    static let shared = InputSourcesService()
+    private init() {}
+
+    func list() -> [KeyboardInputSource] {
+        let filter: [CFString: Any] = [
+            kTISPropertyInputSourceCategory: kTISCategoryKeyboardInputSource,
+            kTISPropertyInputSourceType: kTISTypeKeyboardLayout
+        ]
+        guard let cfList = TISCreateInputSourceList(filter as CFDictionary, false)?.takeRetainedValue() as? [TISInputSource] else {
+            return []
+        }
+        return cfList.compactMap { src in
+            guard
+                let idPtr = TISGetInputSourceProperty(src, kTISPropertyInputSourceID),
+                let id = Unmanaged<CFString>.fromOpaque(idPtr).takeUnretainedValue() as String?,
+                let namePtr = TISGetInputSourceProperty(src, kTISPropertyLocalizedName),
+                let name = Unmanaged<CFString>.fromOpaque(namePtr).takeUnretainedValue() as String?
+            else {
+                return nil
+            }
+            let langsPtr = TISGetInputSourceProperty(src, kTISPropertyInputSourceLanguages)
+            let langs = langsPtr != nil ? (Unmanaged<CFArray>.fromOpaque(langsPtr!).takeUnretainedValue() as? [String]) ?? [] : []
+            return KeyboardInputSource(id: id, name: name, languages: langs)
+        }
+    }
+
+    func resolveLayout(for language: String, overrides: [String: String]? = nil) -> KeyboardInputSource? {
+        let sources = list()
+        if let overrides = overrides, let id = overrides[language], let src = sources.first(where: { $0.id == id }) {
+            return src
+        }
+        return sources.first { $0.languages.contains(language) }
+    }
+}

--- a/app/App/Settings/Defaults.swift
+++ b/app/App/Settings/Defaults.swift
@@ -8,12 +8,13 @@ enum Defaults {
         retro: .init(enabled: true),
         rules: .init(minWordLength: 3),
         apps: .init(blacklist: [], whitelist: []),
+        layouts: .init(active: [], languageMap: [:]),
         hotkeys: .init(toggle: "cmd+shift+space"),
         ui: .init(showMenuBarIcon: true),
         learning: .init(enabled: true),
         privacy: .init(analytics: false),
         performance: .init(debounceMS: 50),
         startup: .init(launchAtLogin: false),
-        version: 1
+        version: 2
     )
 }

--- a/app/App/Settings/Settings.swift
+++ b/app/App/Settings/Settings.swift
@@ -27,6 +27,11 @@ struct Settings: Codable, Equatable {
         var whitelist: [String]
     }
 
+    struct Layouts: Codable, Equatable {
+        var active: [String]
+        var languageMap: [String: String]
+    }
+
     struct Hotkeys: Codable, Equatable {
         var toggle: String
     }
@@ -57,6 +62,7 @@ struct Settings: Codable, Equatable {
     var retro: Retro
     var rules: Rules
     var apps: Apps
+    var layouts: Layouts
     var hotkeys: Hotkeys
     var ui: UI
     var learning: Learning

--- a/app/UI/MenuBar.swift
+++ b/app/UI/MenuBar.swift
@@ -7,7 +7,7 @@ final class MenuBar {
     private var toggleItem: NSMenuItem!
     private var enableItem: NSMenuItem!
     private var quitItem: NSMenuItem!
-    private var prefsWindow: NSWindow?
+    private var prefsController: PreferencesWindowController?
 
     private var isEnabled = true
     var onToggleEnable: ((Bool) -> Void)?
@@ -94,13 +94,10 @@ final class MenuBar {
     }
 
     @objc private func openPrefs() {
-        if prefsWindow == nil {
-            let controller = NSHostingController(rootView: PreferencesView())
-            let window = NSWindow(contentViewController: controller)
-            window.title = "Preferences"
-            prefsWindow = window
+        if prefsController == nil {
+            prefsController = PreferencesWindowController()
         }
-        prefsWindow?.makeKeyAndOrderFront(nil)
+        prefsController?.showWindow(nil)
         NSApp.activate(ignoringOtherApps: true)
     }
 


### PR DESCRIPTION
## Summary
- add `InputSourcesService` for enumerating keyboard layouts and resolving layouts per language
- expand `Settings`/`Defaults` with layout identifiers and language mapping
- build tabbed Preferences window with General tab UI for active layouts and language→layout mapping

## Testing
- `swift build` *(fails: no such module 'SwiftUI')*

------
https://chatgpt.com/codex/tasks/task_e_6897099b8acc832bad862465170aafcf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a Preferences window with a tabbed interface for managing app settings.
  * Added a "General" preferences tab allowing users to select active keyboard layouts and configure language-to-layout mappings.
  * Users can add, remove, and edit language-layout mappings directly from the Preferences window.

* **Improvements**
  * Enhanced keyboard input source management, including listing available layouts and mapping languages to specific layouts.
  * Updated settings structure to support new layout and mapping preferences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->